### PR TITLE
Update bls12 381 to 0.6.1 (faster subgroup checks)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ num_cpus = "1"
 crossbeam = "0.8.1"
 blake2 = "0.10.4"
 #bls12_381 = "0.6"
-bls12_381 = { git = "https://github.com/joebebel/bls12_381" }
+bls12_381 = { git = "https://github.com/joebebel/bls12_381", branch = "joe/fast_subgroup_check"}
 group = "0.11.0"
 ff = "0.11.0"
 rand_chacha = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,34 +1,30 @@
 [package]
-name = "masp-phase2"
-version = "0.2.3"
 authors = ["Sean Bowe <ewillbefull@gmail.com>", "joe@heliax.dev"]
 description = "Library for performing MPCs for creating zk-SNARK public parameters"
 documentation = "https://docs.rs/phase2"
+edition = "2021"
 homepage = "https://github.com/heliaxdev/masp-phase2"
 license = "MIT/Apache-2.0"
+name = "masp-phase2"
 repository = "https://github.com/heliaxdev/masp-phase2"
-edition = "2021"
+version = "0.2.3"
 
 [dependencies]
+bellman = "0.11.1"
+blake2 = "0.10.4"
+bls12_381 = "0.6.1"
+byteorder = "1"
+crossbeam = "0.8.1"
+ff = "0.11.0"
+group = "0.11.0"
+num_cpus = "1"
 pairing = "0.21.0"
 rand = "0.8.5"
-bellman = "0.11.1"
-byteorder = "1"
-num_cpus = "1"
-crossbeam = "0.8.1"
-blake2 = "0.10.4"
-bls12_381 = { version = "0.6" }
-fast_bls12_381 = { package = "bls12_381", git = "https://github.com/joebebel/bls12_381", branch = "joe/fast_subgroup_check", optional = true}
-group = "0.11.0"
-ff = "0.11.0"
 rand_chacha = "0.3.1"
 #zeroize = {version = "1.5.4", features = ["derive"] }
 itertools = "0.10.3"
-rayon = { version = "1.5.1", optional = true }
-
-[features]
-fast-deserialize = ["fast_bls12_381", "rayon"]
+rayon = {version = "1.5.1", optional = true}
 
 [profile.release]
-lto = true
 codegen-units = 1
+lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ byteorder = "1"
 num_cpus = "1"
 crossbeam = "0.8.1"
 blake2 = "0.10.4"
-#bls12_381 = "0.6"
-bls12_381 = { git = "https://github.com/joebebel/bls12_381", branch = "joe/fast_subgroup_check"}
+bls12_381 = { version = "0.6" }
+fast_bls12_381 = { package = "bls12_381", git = "https://github.com/joebebel/bls12_381", branch = "joe/fast_subgroup_check", optional = true}
 group = "0.11.0"
 ff = "0.11.0"
 rand_chacha = "0.3.1"
@@ -27,7 +27,7 @@ itertools = "0.10.3"
 rayon = { version = "1.5.1", optional = true }
 
 [features]
-fast-deserialize = ["rayon"]
+fast-deserialize = ["fast_bls12_381", "rayon"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,17 @@ byteorder = "1"
 num_cpus = "1"
 crossbeam = "0.8.1"
 blake2 = "0.10.4"
-bls12_381 = "0.6"
+#bls12_381 = "0.6"
+bls12_381 = { git = "https://github.com/joebebel/bls12_381" }
 group = "0.11.0"
 ff = "0.11.0"
 rand_chacha = "0.3.1"
 #zeroize = {version = "1.5.4", features = ["derive"] }
 itertools = "0.10.3"
+rayon = { version = "1.5.1", optional = true }
+
+[features]
+fast-deserialize = ["rayon"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bls12_381 = "0.6"
 group = "0.11.0"
 ff = "0.11.0"
 rand_chacha = "0.3.1"
-zeroize = {version = "1.5.4", features = ["derive"] }
+#zeroize = {version = "1.5.4", features = ["derive"] }
 itertools = "0.10.3"
 
 [profile.release]

--- a/src/fast_deserialize.rs
+++ b/src/fast_deserialize.rs
@@ -1,0 +1,157 @@
+use bellman::groth16::{Parameters, VerifyingKey};
+use bls12_381::{Bls12, G1Affine, G2Affine};
+use byteorder::{BigEndian, ReadBytesExt};
+use group::UncompressedEncoding;
+use rayon::prelude::*;
+use std::io::{self, Read};
+use std::sync::Arc;
+
+pub fn read<R: Read>(mut reader: R, checked: bool) -> io::Result<Parameters<Bls12>> {
+    use std::time::Instant;
+    let now = Instant::now();
+    let read_g1 = |reader: &mut R| -> io::Result<<G1Affine as UncompressedEncoding>::Uncompressed> {
+        let mut repr = <G1Affine as UncompressedEncoding>::Uncompressed::default();
+        reader.read_exact(repr.as_mut())?;
+        Ok(repr)
+    };
+    let process_g1 =
+        |repr: &<G1Affine as UncompressedEncoding>::Uncompressed| -> io::Result<G1Affine> {
+            let affine = if checked {
+                <G1Affine as UncompressedEncoding>::from_uncompressed(repr)
+            } else {
+                <G1Affine as UncompressedEncoding>::from_uncompressed_unchecked(repr)
+            };
+
+            let affine = if affine.is_some().into() {
+                Ok(affine.unwrap())
+            } else {
+                Err(io::Error::new(io::ErrorKind::InvalidData, "invalid G1"))
+            };
+
+            affine.and_then(|e| {
+                if e.is_identity().into() {
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "point at infinity",
+                    ))
+                } else {
+                    Ok(e)
+                }
+            })
+        };
+
+    let read_g2 = |reader: &mut R| -> io::Result<<G2Affine as UncompressedEncoding>::Uncompressed> {
+        let mut repr = <G2Affine as UncompressedEncoding>::Uncompressed::default();
+        reader.read_exact(repr.as_mut())?;
+        Ok(repr)
+    };
+
+    let process_g2 =
+        |repr: &<G2Affine as UncompressedEncoding>::Uncompressed| -> io::Result<G2Affine> {
+            let affine = if checked {
+                <G2Affine as UncompressedEncoding>::from_uncompressed(repr)
+            } else {
+                <G2Affine as UncompressedEncoding>::from_uncompressed_unchecked(repr)
+            };
+
+            let affine = if affine.is_some().into() {
+                Ok(affine.unwrap())
+            } else {
+                Err(io::Error::new(io::ErrorKind::InvalidData, "invalid G2"))
+            };
+
+            affine.and_then(|e| {
+                if e.is_identity().into() {
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "point at infinity",
+                    ))
+                } else {
+                    Ok(e)
+                }
+            })
+        };
+
+    let vk = VerifyingKey::<Bls12>::read(&mut reader)?;
+    println!("VerifyingKey: {:.2?}", now.elapsed());
+
+    let h;
+    let l;
+    let a;
+    let b_g1;
+    let b_g2;
+
+    {
+        let len = reader.read_u32::<BigEndian>()? as usize;
+        let mut h_raw = Vec::with_capacity(len);
+        for _ in 0..len {
+            h_raw.push(read_g1(&mut reader)?);
+        }
+        h = h_raw
+            .par_iter()
+            .map(process_g1)
+            .collect::<io::Result<Vec<_>>>()?;
+    }
+    println!("h: {:.2?}", now.elapsed());
+
+    {
+        let len = reader.read_u32::<BigEndian>()? as usize;
+        let mut l_raw = Vec::with_capacity(len);
+        for _ in 0..len {
+            l_raw.push(read_g1(&mut reader)?);
+        }
+        l = l_raw
+            .par_iter()
+            .map(process_g1)
+            .collect::<io::Result<Vec<_>>>()?;
+    }
+    println!("l: {:.2?}", now.elapsed());
+
+    {
+        let len = reader.read_u32::<BigEndian>()? as usize;
+        let mut a_raw = Vec::with_capacity(len);
+        for _ in 0..len {
+            a_raw.push(read_g1(&mut reader)?);
+        }
+        a = a_raw
+            .par_iter()
+            .map(process_g1)
+            .collect::<io::Result<Vec<_>>>()?;
+    }
+    println!("a: {:.2?}", now.elapsed());
+
+    {
+        let len = reader.read_u32::<BigEndian>()? as usize;
+        let mut b_g1_raw = Vec::with_capacity(len);
+        for _ in 0..len {
+            b_g1_raw.push(read_g1(&mut reader)?);
+        }
+        b_g1 = b_g1_raw
+            .par_iter()
+            .map(process_g1)
+            .collect::<io::Result<Vec<_>>>()?;
+    }
+    println!("b_g1: {:.2?}", now.elapsed());
+
+    {
+        let len = reader.read_u32::<BigEndian>()? as usize;
+        let mut b_g2_raw = Vec::with_capacity(len);
+        for _ in 0..len {
+            b_g2_raw.push(read_g2(&mut reader)?);
+        }
+        b_g2 = b_g2_raw
+            .par_iter()
+            .map(process_g2)
+            .collect::<io::Result<Vec<_>>>()?;
+    }
+    println!("b_g2: {:.2?}", now.elapsed());
+
+    Ok(Parameters {
+        vk,
+        h: Arc::new(h),
+        l: Arc::new(l),
+        a: Arc::new(a),
+        b_g1: Arc::new(b_g1),
+        b_g2: Arc::new(b_g2),
+    })
+}

--- a/src/fast_deserialize.rs
+++ b/src/fast_deserialize.rs
@@ -1,6 +1,6 @@
 use bellman::groth16::{Parameters, VerifyingKey};
-use bls12_381::{Bls12, G1Affine, G2Affine};
 use byteorder::{BigEndian, ReadBytesExt};
+use fast_bls12_381::{Bls12, G1Affine, G2Affine};
 use group::UncompressedEncoding;
 use rayon::prelude::*;
 use std::io::{self, Read};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,12 +217,6 @@ use bellman::multicore::Worker;
 #[cfg(feature = "wasm")]
 use bellman::singlecore::Worker;
 
-#[cfg(feature = "fast-deserialize")]
-pub mod fast_deserialize;
-#[cfg(feature = "fast-deserialize")]
-use fast_bls12_381::{Bls12, G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
-
-#[cfg(not(feature = "fast-deserialize"))]
 use bls12_381::{Bls12, G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
 
 use bellman::{
@@ -966,9 +960,6 @@ impl MPCParameters {
     /// we won't perform curve validity and group order
     /// checks.
     pub fn read<R: Read>(mut reader: R, checked: bool) -> io::Result<MPCParameters> {
-        #[cfg(feature = "fast-deserialize")]
-        let params = fast_deserialize::read(&mut reader, checked)?;
-        #[cfg(not(feature = "fast-deserialize"))]
         let params = Parameters::read(&mut reader, checked)?;
 
         let mut cs_hash = [0u8; 64];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ use bellman::{
     groth16::{Parameters, VerifyingKey},
     Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable,
 };
-use zeroize::{Zeroize, ZeroizeOnDrop};
+//use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -721,12 +721,16 @@ impl MPCParameters {
     /// sure their contribution is in the final parameters, by
     /// checking to see if it appears in the output of
     /// `MPCParameters::verify`.
-    pub fn contribute<R: Rng>(&mut self, rng: &mut R) -> [u8; 64] {
+    pub fn contribute<R: Rng>(&mut self, rng: &mut R, progress_update_interval: &u32) -> [u8; 64] {
         // Generate a keypair
         let (pubkey, privkey) = keypair(rng, self);
 
-        fn batch_exp<C: PrimeCurveAffine>(bases: &mut [C], coeff: <C as PrimeCurveAffine>::Scalar)
-        where
+        fn batch_exp<C: PrimeCurveAffine>(
+            bases: &mut [C],
+            coeff: <C as PrimeCurveAffine>::Scalar,
+            progress_update_interval: &u32,
+            total_exps: &u32,
+        ) where
             C::Curve: WnafGroup,
         {
             //let coeff = coeff.to_repr();
@@ -747,9 +751,15 @@ impl MPCParameters {
                 {
                     scope.spawn(move |_scope| {
                         let mut wnaf = Wnaf::new();
-
+                        let mut count = 0;
                         for (base, projective) in bases.iter_mut().zip(projective.iter_mut()) {
                             *projective = wnaf.base(base.to_curve(), 1).scalar(&coeff);
+                            count = count + 1;
+                            if *progress_update_interval > 0
+                                && count % *progress_update_interval == 0
+                            {
+                                println!("progress {} {}", *progress_update_interval, *total_exps)
+                            }
                         }
                     });
                 }
@@ -778,8 +788,9 @@ impl MPCParameters {
         let delta_inv = privkey.delta.invert().unwrap(); //expect("nonzero");
         let mut l = (&self.params.l[..]).to_vec();
         let mut h = (&self.params.h[..]).to_vec();
-        batch_exp(&mut l, delta_inv);
-        batch_exp(&mut h, delta_inv);
+        let total_exps = (l.len() + h.len()) as u32;
+        batch_exp(&mut l, delta_inv, &progress_update_interval, &total_exps);
+        batch_exp(&mut h, delta_inv, &progress_update_interval, &total_exps);
         self.params.l = Arc::new(l);
         self.params.h = Arc::new(h);
 
@@ -1005,10 +1016,11 @@ impl PublicKey {
 
     fn read<R: Read>(mut reader: R) -> io::Result<PublicKey> {
         let read_g1 = |reader: &mut R| -> io::Result<G1Affine> {
-            let mut g1_repr = <G1Affine as GroupEncoding>::Repr::default();
+            let mut g1_repr = <G1Affine as UncompressedEncoding>::Uncompressed::default();
             reader.read_exact(g1_repr.as_mut())?;
 
-            let affine = G1Affine::from_bytes(&g1_repr);
+            let affine = <G1Affine as UncompressedEncoding>::from_uncompressed(&g1_repr);
+
             let affine = if affine.is_some().into() {
                 Ok(affine.unwrap())
             } else {
@@ -1028,10 +1040,10 @@ impl PublicKey {
         };
 
         let read_g2 = |reader: &mut R| -> io::Result<G2Affine> {
-            let mut g2_repr = <G2Affine as GroupEncoding>::Repr::default();
+            let mut g2_repr = <G2Affine as UncompressedEncoding>::Uncompressed::default();
             reader.read_exact(g2_repr.as_mut())?;
 
-            let affine = G2Affine::from_bytes(&g2_repr);
+            let affine = <G2Affine as UncompressedEncoding>::from_uncompressed(&g2_repr);
             let affine = if affine.is_some().into() {
                 Ok(affine.unwrap())
             } else {
@@ -1341,11 +1353,9 @@ fn keypair<R: Rng>(mut rng: R, current: &MPCParameters) -> (PublicKey, PrivateKe
 fn hash_to_g2(digest: &[u8]) -> G2Projective {
     assert!(digest.len() >= 32);
 
-    G2Projective::random(ChaChaRng::from_seed(
-        digest
-            .try_into()
-            .unwrap_or_else(|_| panic!("assertion above guarantees this to work")),
-    ))
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&digest[0..32]);
+    G2Projective::random(ChaChaRng::from_seed(seed))
 }
 
 /// Abstraction over a writer which hashes the data being written.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,6 @@ use std::{
 };
 
 use blake2::Digest;
-use bls12_381::{Bls12, G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Curve, Group, UncompressedEncoding, Wnaf, WnafGroup};
 use pairing::PairingCurveAffine;
@@ -220,6 +219,11 @@ use bellman::singlecore::Worker;
 
 #[cfg(feature = "fast-deserialize")]
 pub mod fast_deserialize;
+#[cfg(feature = "fast-deserialize")]
+use fast_bls12_381::{Bls12, G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
+
+#[cfg(not(feature = "fast-deserialize"))]
+use bls12_381::{Bls12, G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
 
 use bellman::{
     groth16::{Parameters, VerifyingKey},


### PR DESCRIPTION
Version 0.6.1 implements [PR #83](https://github.com/zkcrypto/bls12_381/pull/83) add fast subgroup check for is_torsion_free. Removed unnecessary patch with feature flag "fast-deserialize"